### PR TITLE
Adds an immutable `givenText` property to `AIDData`.

### DIFF
--- a/src/aidData.js
+++ b/src/aidData.js
@@ -1,4 +1,4 @@
-const $$givenText = Symbol("AIDData.givenText")
+const $$givenText = Symbol('AIDData.givenText')
 
 class AIDData {
   constructor (text, state, info, worldEntries, history) {

--- a/src/aidData.js
+++ b/src/aidData.js
@@ -1,6 +1,9 @@
+const $$givenText = Symbol("AIDData.givenText")
+
 class AIDData {
   constructor (text, state, info, worldEntries, history) {
     this.text = text
+    this[$$givenText] = text
     this.state = state
     this.info = info
     this.worldEntries = worldEntries
@@ -22,6 +25,10 @@ class AIDData {
 
   get message () {
     return this.state.message
+  }
+
+  get givenText () {
+    return this[$$givenText]
   }
 
   get actionCount () {


### PR DESCRIPTION
As each plugin performs its work, they manipulate the `text` property.  This manipulation means the next plugin may not be getting the original input from the player.

This adds an immutable `givenText` property to `AIDData`, so that plugins have a means of getting that original, unaltered input text, no matter how deep in a chain of plugins they are.

The field is protected from manipulation by a module-scoped private `Symbol` property.  Not full-proof, since it's Javascript and all, but you need to go to some serious effort to break the contract.