### PR TITLE
Feature/add player memory to aiddata

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ class Pipeline {
   }
 
   build () {
-    global.inputModifier = (text, state, info, worldEntries, history) => {
-      const data = new AIDData(text, state, info, worldEntries, history)
+    global.inputModifier = (text, state, info, worldEntries, history, memory) => {
+      const data = new AIDData(text, state, info, worldEntries, history, memory)
       const command = this.commandHandler.checkCommand(data)
 
       if (!command || !command.stopsPlugins) {
@@ -27,8 +27,8 @@ class Pipeline {
       return data.finalizeOutput()
     }
 
-    global.contextModifier = (text, state, info, worldEntries, history) => {
-      const data = new AIDData(text, state, info, worldEntries, history)
+    global.contextModifier = (text, state, info, worldEntries, history, memory) => {
+      const data = new AIDData(text, state, info, worldEntries, history, memory)
 
       for (const plugin of this.plugins) {
         plugin.contextModifier(data)
@@ -37,8 +37,8 @@ class Pipeline {
       return data.finalizeOutput()
     }
 
-    global.outputModifier = (text, state, info, worldEntries, history) => {
-      const data = new AIDData(text, state, info, worldEntries, history)
+    global.outputModifier = (text, state, info, worldEntries, history, memory) => {
+      const data = new AIDData(text, state, info, worldEntries, history, memory)
 
       for (const plugin of this.plugins) {
         plugin.outputModifier(data)

--- a/lib/contextModifier.js
+++ b/lib/contextModifier.js
@@ -1,5 +1,5 @@
 const modifier = (text) => {
-  return global.contextModifier(text, state, info, worldEntries, history)
+  return global.contextModifier(text, state, info, worldEntries, history, memory)
 }
 
 // Don't modify this part

--- a/lib/inputModifier.js
+++ b/lib/inputModifier.js
@@ -1,5 +1,5 @@
 const modifier = (text) => {
-  return global.inputModifier(text, state, info, worldEntries, history)
+  return global.inputModifier(text, state, info, worldEntries, history, memory)
 }
 
 // Don't modify this part

--- a/lib/outputModifier.js
+++ b/lib/outputModifier.js
@@ -1,5 +1,5 @@
 const modifier = (text) => {
-  return global.outputModifier(text, state, info, worldEntries, history)
+  return global.outputModifier(text, state, info, worldEntries, history, memory)
 }
 
 // Don't modify this part

--- a/src/aidData.js
+++ b/src/aidData.js
@@ -1,4 +1,4 @@
-const $$givenPlayerMemory = Symbol("AIDData.givenPlayerMemory")
+const $$givenPlayerMemory = Symbol('AIDData.givenPlayerMemory')
 
 class AIDData {
   constructor (text, state, info, worldEntries, history, memory) {

--- a/src/aidData.js
+++ b/src/aidData.js
@@ -1,10 +1,11 @@
 class AIDData {
-  constructor (text, state, info, worldEntries, history) {
+  constructor (text, state, info, worldEntries, history, memory) {
     this.text = text
     this.state = state
     this.info = info
     this.worldEntries = worldEntries
     this.history = history
+    this.playerMemory = memory
     this.useAI = true
     delete state.message
   }

--- a/src/aidData.js
+++ b/src/aidData.js
@@ -1,3 +1,5 @@
+const $$givenPlayerMemory = Symbol("AIDData.givenPlayerMemory")
+
 class AIDData {
   constructor (text, state, info, worldEntries, history, memory) {
     this.text = text
@@ -6,6 +8,7 @@ class AIDData {
     this.worldEntries = worldEntries
     this.history = history
     this.playerMemory = memory
+    this[$$givenPlayerMemory] = memory
     this.useAI = true
     delete state.message
   }
@@ -23,6 +26,10 @@ class AIDData {
 
   get message () {
     return this.state.message
+  }
+
+  get givenPlayerMemory () {
+    return this[$$givenPlayerMemory]
   }
 
   get actionCount () {


### PR DESCRIPTION
Corrects an oversight: there's no access to `globalThis.memory`, the player-set memory set by the `/remember` command, in `AIDData`.

The basic `playerMemory` property is mutable, but an immutable `givenPlayerMemory` property exists as well.  This allows plugins to manipulate `playerMemory` and share the transformations with other plugins, which may be handy for plugins focused on constructing a custom context.