### PR TITLE
Replaces Browserify with Webpack.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "adm-zip": "^0.4.16",
     "shebang-loader": "^0.0.1",
-    "stripcomment-loader": "^0.1.0",
     "webpack": "^5.37.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
   "homepage": "https://github.com/TheDudeFromCI/aid-bundler#readme",
   "dependencies": {
     "adm-zip": "^0.4.16",
-    "browserify": "^17.0.0",
-    "fs": "0.0.1-security",
-    "path": "^0.12.7"
+    "shebang-loader": "^0.0.1",
+    "stripcomment-loader": "^0.1.0",
+    "webpack": "^5.37.0"
   },
   "devDependencies": {
-    "@types/browserify": "^12.0.36",
+    "@types/webpack": "^4.41.0",
     "require-self": "^0.2.3",
     "standard": "^16.0.1"
   },

--- a/src/aidData.js
+++ b/src/aidData.js
@@ -1,4 +1,3 @@
-const $$givenText = Symbol('AIDData.givenText')
 const $$givenPlayerMemory = Symbol('AIDData.givenPlayerMemory')
 const $$givenText = Symbol('AIDData.givenText')
 
@@ -29,10 +28,6 @@ class AIDData {
 
   get message () {
     return this.state.message
-  }
-
-  get givenText () {
-    return this[$$givenText]
   }
 
   get givenPlayerMemory () {


### PR DESCRIPTION
I ran into issues with Browserify; it is incapable of parsing the ES6 `import` and `export` syntax that is becoming more common in Node packages with the v14 release.

So, I slipped Webpack in its place.  It appears to produce comparable output at about the same rate.

There is also a "production release" mode that can be activated with `NODE_ENV=production npm run bundle` that will apply some basic minification and comment stripping to squeeze those ZIP files down a bit for distribution.

It preserves all identifiers so they are more traceable when an error is encountered as AID is executing the script, so users of the script pack can report coherent errors to the script's author.